### PR TITLE
AEYB #10 Fix building backend requires frontend dependencies

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -6,5 +6,6 @@
         "target": "es2016",
         "module": "commonjs",
         "outDir": "./dist"
-    }
+    },
+    "include": ["src/**/*.ts"]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -11,5 +11,6 @@
         "isolatedModules": true,
         "noEmit": true,
         "jsx": "react-jsx"
-    }
+    },
+    "include": ["src/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,5 @@
         "allowSyntheticDefaultImports": true,
         "noFallthroughCasesInSwitch": true
     },
-    "include": ["**/src/**/*.ts"],
     "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Fixes #10 

The issue is that the base `tsconfig` file included the src files of both the frontend and backend, hence when trying to build the backend, it also tried to build the frontend and complained when the dependencies were missing.

By moving the includes to the individual `tsconfig` files, this prevents the separate mono-repos from being included in the building of one another.
