### PR TITLE
#35 Add token expired response

### DIFF
--- a/backend/src/middleware/AuthMiddleware.ts
+++ b/backend/src/middleware/AuthMiddleware.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from 'express';
 import asyncHandler from 'express-async-handler';
 import config from '../types/Config';
-import jwt from 'jsonwebtoken';
+import jwt, { TokenExpiredError } from 'jsonwebtoken';
 import User from '../models/UserModel';
 import Permission from '../types/Perm';
 import { getPermissions } from '../controllers/UserController';
@@ -39,6 +39,10 @@ export default function protect(permission?: Permission): AuthenticationFunction
 
             next();
         } catch (error) {
+            if (error instanceof TokenExpiredError) {
+                // Give the frontend some feedback so they know to get a new token
+                return res.tokenExpired(error);
+            }
             res.unauthorized('Something went wrong while authenticating the request: ' + (error as Error).message);
         }
     });

--- a/backend/src/types/ResponseAugmentation.ts
+++ b/backend/src/types/ResponseAugmentation.ts
@@ -1,4 +1,5 @@
 import { response } from 'express';
+import { TokenExpiredError } from 'jsonwebtoken';
 
 type DataType = Record<string, unknown> & { data?: Record<string, unknown> };
 
@@ -11,6 +12,7 @@ declare module 'express-serve-static-core' {
         error(status: number, message: string): void;
         invalid(message: string): void;
         unauthorized(message: string): void;
+        tokenExpired(error: TokenExpiredError): void;
         notFound(message: string): void;
         success(status: number, data: DataType): void;
         ok(data: DataType): void;
@@ -34,6 +36,14 @@ response.unauthorized = function (message) {
     this.status(401).json({
         status: 'unauthorized',
         message,
+    });
+};
+
+response.tokenExpired = function (error) {
+    this.status(401).json({
+        status: 'tokenExpired',
+        messsage: error.message,
+        expiredAt: error.expiredAt,
     });
 };
 


### PR DESCRIPTION
Fixes #35 

Originally, when your token expired you would only be able to identify this by inspecting the message, which would be `jwt expired`. While this did allow you to determine the issue, it wasn't consistent with using the `status` field to clarify the type of the issue.

This PR adds a new status type `tokenExpired` which can be returned by any endpoint that requires authorization. An expired token response looks like:

Status: `401`
```json
{
    "status": "tokenExpired",
    "messsage": "jwt expired",
    "expiredAt": "2022-08-20T00:57:03.000Z"
}
```

When you receive this response, you would then need to get the user to login again (`/api/users/login`) to retrieve a new token.