### PR TITLE
Seeded database with initial roles

### DIFF
--- a/backend/src/classes/Server.ts
+++ b/backend/src/classes/Server.ts
@@ -7,6 +7,7 @@ import { Config } from '../types/Config';
 import mongoose from 'mongoose';
 import ErrorHandler from '../middleware/ErrorMiddleware';
 import cors from 'cors';
+import { createDefaultRoles } from '../services/RoleServices';
 
 export default class Server {
     private _app: Express;
@@ -24,6 +25,7 @@ export default class Server {
     private init(): Server {
         // Make sure the db is connected before registering routes
         this.connectDB().then(() => this.configureApp());
+        createDefaultRoles();
         return this;
     }
 

--- a/backend/src/controllers/RoleController.ts
+++ b/backend/src/controllers/RoleController.ts
@@ -58,13 +58,17 @@ const addRole = asyncHandler(async (req: TypedRequest<RoleDTO>, res: TypedRespon
  * @route 	PATCH /api/roles/:roleId
  */
 const updateRole = asyncHandler(async (req: TypedRequest<RoleDTO, RoleIdParam>, res: TypedResponse<UpdateRoleData>) => {
-    const role = await Role.findByIdAndUpdate(req.params.roleId, req.body, {
-        new: true,
-        runValidators: true,
-    });
+    const role = await Role.findOneAndUpdate(
+        { _id: req.params.roleId, name: { $ne: ['Default', 'Admin'] } },
+        req.body,
+        {
+            new: true,
+            runValidators: true,
+        },
+    );
 
     if (!role) {
-        return res.notFound(`There is no role with the id ${req.params.roleId}`);
+        return res.notFound(`There is no valid role with the id ${req.params.roleId}`);
     }
 
     res.ok({ role });

--- a/backend/src/controllers/UserController.ts
+++ b/backend/src/controllers/UserController.ts
@@ -26,6 +26,7 @@ import {
 } from '@shared/responses/UserResponsesData';
 import { Permission } from '@shared/utils/Permission';
 import { Request } from 'express';
+import { createNewUser } from '../services/UserService';
 
 const client = new OAuth2Client(config.clientID);
 
@@ -67,11 +68,7 @@ const loginUser = asyncHandler(async (req: Request<LoginRequest>, res: TypedResp
 
         let user = await User.findById(payload.userId);
         if (!user) {
-            user = await User.create({
-                _id: payload.userId,
-                name: payload.name,
-                profileUrl: payload.profileUrl,
-            });
+            user = await createNewUser(payload);
         } else if (user.name !== payload.name || user.profileUrl !== payload.profileUrl) {
             // If the profile picture or name doesn't match, it must have been updated so we need to update our internal record
             const tempUser = await User.findByIdAndUpdate(

--- a/backend/src/models/RoleModel.ts
+++ b/backend/src/models/RoleModel.ts
@@ -1,6 +1,5 @@
 import mongoose from 'mongoose';
 import RoleDTO from '@shared/dtos/RoleDTO';
-import { Permission } from '@shared/utils/Permission';
 import { DocumentModel } from '../types/UtilTypes';
 import { applyToJsonOptions } from './Utils';
 

--- a/backend/src/services/RoleServices.ts
+++ b/backend/src/services/RoleServices.ts
@@ -1,0 +1,23 @@
+import Role from '../models/RoleModel';
+
+export const createDefaultRoles = async () => {
+    const roleCount = await Role.countDocuments();
+
+    if (roleCount !== 0) {
+        return;
+    }
+
+    const defaultRole = new Role({
+        name: 'Default',
+        color: '#262b6c',
+        permissions: ['VIEW_MEETINGS'],
+    });
+    const adminRole = new Role({
+        name: 'Admin',
+        color: '#262b6c',
+        permissions: ['VIEW_MEETINGS', 'VIEW_USERS', 'VIEW_ROLES', 'MANAGE_MEETINGS', 'MANAGE_ROLES', 'MANAGE_USERS'],
+    });
+
+    await defaultRole.save();
+    await adminRole.save();
+};

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -1,0 +1,19 @@
+import Role from '../models/RoleModel';
+import User from '../models/UserModel';
+import GooglePayload from '../types/GooglePayload';
+
+export const createNewUser = async ({ userId, name, profileUrl }: GooglePayload) => {
+    const userCount = await User.countDocuments();
+    let roles;
+    if (userCount === 0) {
+        roles = await Role.find({ name: 'Admin' });
+    } else {
+        roles = await Role.find({ name: 'Default' });
+    }
+    return await User.create({
+        _id: userId,
+        name,
+        profileUrl: profileUrl,
+        roles,
+    });
+};


### PR DESCRIPTION
**Closes:** #113 

**What was done:**

- Seeded database with initial Roles
- 1st user gets an admin role
- Other users get default role, thereby removing the error on the profile page
- Implemented services pattern
- Made `Default` and `Admin` roles immutable

**How to test:**

-  [x] Change the `mongo_uri` to a different db instance.
-  [x] And login with the first account => This account should have the `Admin` role.
-  [x] Login with your second account => This account should have the `Default` role.
-  [x] Try to edit the `Default` and `Admin` roles, it shouldn't save